### PR TITLE
Fix issue with minimum temperature

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ function Thermostat(log, config) {
     this.manufacturer = config.manufacturer || 'DefaultManufacturer';
     this.model = config.model || 'DefaultModel';
     this.temperatureDisplayUnits = config.temperatureDisplayUnits || 1;
-    this.minTemperature = config.maxTemperature || 62;
+    this.minTemperature = config.minTemperature || 62;
     this.maxTemperature = config.maxTemperature || 86;
     this.commandDelay = config.commandDelay || 10;
     this.service = new Service.Thermostat(this.name);


### PR DESCRIPTION
This should fix #3 - I had the same issue occurring where it was always ending up setting to 86 degrees. The reason was that the config was set in homebridge and `config.maxTemperature` was defined, which caused `minTemperature` to be set to 86.